### PR TITLE
fix: Replace python shebangs with /usr/libexec/platform-python

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,13 @@ jobs:
         run: >-
           docker run --rm
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
-          "python --version --version && echo '' && python -m pip list"
+          'python --version --version && echo "" && python -m pip list'
+
+      - name: Check yum still works after shebang manipulation
+        run: >-
+          docker run --rm
+          neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
+          'yum --version --version'
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,7 @@ jobs:
         run: >-
           docker run --rm
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
-          'yum --version --version'
+          'yum --version'
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ WORKDIR /build
 # done to ensure that non-interatice sessions don't cause unintended bugs.
 # As soon as NCSA Blue Waters is EOL and no longer needed, switch over to
 # centos:8 immediatley.
+# The grep bit at the end:
+# * Finds all matches under /usr/bin that contain #!/usr/bin/python
+# * Ignores all matches with python3 or python2.7
+# * Strips out just the filename
+# * Passes those filenames to sed to replace the shebang with #!/usr/libexec/platform-python
 RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" && \
     tar -xzf "Python-${PYTHON_VERSION}.tgz" && \
     cd "Python-${PYTHON_VERSION}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ ARG PYTHON_VERSION=3.8.8
 WORKDIR /build
 # Ensure that python means python3 even in non-interactive sessions through
 # aliases and symbolic links
+# N.B.:
+# This is a bad thing to do in general and this is ONLY being done to ensure
+# that non-interatice sessions don't cause unintended bugs.
+# As soon as NCSA Blue Waters is EOL and no longer needed, switch over to
+# centos:8 immediatley.
 RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" && \
     tar -xzf "Python-${PYTHON_VERSION}.tgz" && \
     cd "Python-${PYTHON_VERSION}" && \


### PR DESCRIPTION
Resolves #2 

Ensure that CentOS 7 files that use the shebang `#!/usr/bin/python` don't break when `python` changes to `python3` by updating the shebang to `#!usr/libexec/platform-python` like CentOS 8 does

```console
$ docker run --rm centos:8 /bin/bash -c 'head -n 1 $(command -v yum)'
#!/usr/libexec/platform-python
```

The long `grep` bit at the end that does this 

```bash
grep --recursive '#!/usr/bin/python' /usr/bin/ \
    | grep --invert-match 'python3\|python2.7' \
    | sed 's/:.*$//' \
    | xargs sed --in-place 's|#!/usr/bin/python|#!/usr/libexec/platform-python|g'
```

does the following:

* Finds all matches under `/usr/bin` that contain `#!/usr/bin/python`
* Ignores all matches with `python3` or `python2.7`
* Strips out just the filename
* Passes those filenames to sed to replace the shebang with `#!/usr/libexec/platform-python`

```
* Ensure that CentOS 7 files that use the shebang `#!/usr/bin/python` don't break when `python` changes to `python3` by updating the shebang to `#!/usr/libexec/platform-python`
* Add test for shebang update using yum
```