### PR TITLE
fix: Replace python shebangs in programs under /usr/libexec/

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,7 @@ jobs:
         run: >-
           docker run --rm
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
-          'yum --version'
+          'yum --version && yum update -y'
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,11 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     grep --recursive '#!/usr/bin/python' /usr/bin/ \
         | grep --invert-match 'python3\|python2.7' \
         | sed 's/:.*$//' \
-        | xargs sed --in-place 's|#!/usr/bin/python|#!/usr/libexec/platform-python|g'
+        | xargs sed --in-place 's|#!/usr/bin/python|#!/usr/libexec/platform-python|g' && \
+    grep --recursive '#!' /usr/libexec/ \
+        | grep "python" \
+        | sed 's/:.*$//' \
+        | xargs sed --in-place 's|/usr/bin/python|/usr/libexec/platform-python|g'
 WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Resolves #4 

```
* Update the python shebang in files under /usr/libexec/ from #!/usr/bin/python to #!usr/libexec/platform-python
   - Needed for /usr/libexec/urlgrabber-ext-down
* Add check that `yum update` works
```