### PR TITLE
feat: Make Python.h findable by gcc

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Check gcc finds /usr/include/python3.8/Python.h
         run: >-
           docker run --rm
-          -v $PWD:PWD
+          -v $PWD:$PWD
           -w $PWD
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
           'gcc tests/test-gcc-include.c -o test-gcc-include && ./test-gcc-include'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,6 +102,14 @@ jobs:
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
           'yum --version && yum update -y'
 
+      - name: Check gcc finds /usr/include/python3.8/Python.h
+        run: >-
+          docker run --rm
+          -v $PWD:PWD
+          -w $PWD
+          neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
+          'gcc tests/test-gcc-include.c -o test-gcc-include && ./test-gcc-include'
+
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 # Make /usr/include/python3.8/Python.h findable to gcc
-# c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.1/gcc/Environment-Variables.html#Environment-Variables
+# c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
 ENV C_INCLUDE_PATH=/usr/include/python3.8
 ENV CPLUS_INCLUDE_PATH=/usr/include/python3.8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN yum update -y && \
         bzip2-devel \
         libffi-devel \
         lzma-devel \
+        python3-devel \
         curl \
         tar \
         make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,8 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 # Make /usr/include/python3.8/Python.h findable to gcc
 # c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.1/gcc/Environment-Variables.html#Environment-Variables
-ENV C_INCLUDE_PATH="/usr/include/python3.8"
-ENV CPLUS_INCLUDE_PATH="/usr/include/python3.8"
+ENV C_INCLUDE_PATH=/usr/include/python3.8
+ENV CPLUS_INCLUDE_PATH=/usr/include/python3.8
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN yum update -y && \
         bzip2-devel \
         libffi-devel \
         lzma-devel \
-        python3-devel \
         curl \
         tar \
         make && \
@@ -59,6 +58,10 @@ WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
+# Make /usr/include/python3.8/Python.h findable to gcc
+# c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.1/gcc/Environment-Variables.html#Environment-Variables
+ENV C_INCLUDE_PATH="/usr/include/python3.8"
+ENV CPLUS_INCLUDE_PATH="/usr/include/python3.8"
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-# Make /usr/include/python3.8/Python.h findable to gcc
+# Make /usr/include/python3.8/Python.h findable by gcc
 # c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
 ENV C_INCLUDE_PATH=/usr/include/python3.8
 ENV CPLUS_INCLUDE_PATH=/usr/include/python3.8

--- a/tests/test-gcc-include.c
+++ b/tests/test-gcc-include.c
@@ -1,0 +1,8 @@
+#include<Python.h>
+#include<stdio.h>
+// https://askubuntu.com/questions/591930/python-h-found-by-locate-but-not-by-gcc
+int main()
+{
+    printf("this is a python header file included programm\n");
+    return 0;
+}


### PR DESCRIPTION
Make `/usr/include/python3.8/Python.h` findable by `gcc` by adding `/usr/include/python3.8` to `C_INCLUDE_PATH` and `CPLUS_INCLUDE_PATH`.


```
* Set environment variables C_INCLUDE_PATH and CPLUS_INCLUDE_PATH to /usr/include/python3.8
   - Makes Python.h from CPython install findable to gcc
   - c.f. c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
* Add test C file to build in CI that includes Python.h
```