### PR TITLE
feat: Update CPython version to v8.3.10

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           DOCKER_IMAGE=neubauergroup/centos-python3
           VERSION=latest
-          PYTHON_VERSION=3.8.8
+          PYTHON_VERSION=3.8.10
           REPO_NAME=${{github.repository}}
           REPO_NAME_LOWERCASE="${REPO_NAME,,}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
             VERSION=pr-${{ github.event.number }}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:3.8.8,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:${PYTHON_VERSION},${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           # Releases also have GITHUB_REFs that are tags, so reuse VERSION
           if [ "${{ github.event_name }}" = "release" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:${VERSION}"
@@ -48,6 +48,7 @@ jobs:
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=repo_name_lowercase::"${REPO_NAME_LOWERCASE}"
+          echo ::set-output name=python_version::"${PYTHON_VERSION}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -118,7 +119,11 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          tags: neubauergroup/centos-python3:latest,neubauergroup/centos-python3:3.8.8,ghcr.io/${{steps.prep.outputs.repo_name_lowercase}}:latest,ghcr.io/${{steps.prep.outputs.repo_name_lowercase}}:3.8.8
+          tags: |
+            neubauergroup/centos-python3:latest
+            neubauergroup/centos-python3:${{ steps.prep.outputs.python_version }}
+            ghcr.io/${{ steps.prep.outputs.repo_name_lowercase }}:latest
+            ghcr.io/${{ steps.prep.outputs.repo_name_lowercase }}:${{ steps.prep.outputs.python_version }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN yum update -y && \
         make && \
     yum clean all
 
-ARG PYTHON_VERSION=3.8.8
+ARG PYTHON_VERSION=3.8.10
 WORKDIR /build
 # Ensure that python means python3 even in non-interactive sessions through
 # aliases and symbolic links

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ image:
 	docker pull centos:7
 	docker build . \
 		--file Dockerfile \
-		--build-arg PYTHON_VERSION=3.8.8 \
+		--build-arg PYTHON_VERSION=3.8.10 \
 		--tag neubauergroup/centos-python3:debug-local


### PR DESCRIPTION
Update to CPython version [`8.3.10`](https://www.python.org/downloads/release/python-3810/)

```
* Update CPython to v8.3.10
   - c.f. https://www.python.org/downloads/release/python-3810/
* Set CPython version number for full CI workflow with step output variables
```