### PR TITLE
feat: Match environmental variables in official Python images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,6 +91,12 @@ jobs:
       - name: List built images
         run: docker images
 
+      - name: Check environment variables
+        run: >-
+          docker run --rm
+          neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
+          'printenv'
+
       - name: Check CPython version
         run: >-
           docker run --rm

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ ENV C_INCLUDE_PATH=/usr/include/python3.8
 ENV CPLUS_INCLUDE_PATH=/usr/include/python3.8
 # Match official Python docker image environment variables
 ENV PYTHON_VERSION="${PYTHON_VERSION}"
-ENV PYTHON_PIP_VERSION="$(python -c 'import pip; print(pip.__version__)')"
+# pip version needs to be determined empirically for each CPython
+# release as ENV can't be set from RUN output
+ENV PYTHON_PIP_VERSION=21.1.1
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,9 @@ ENV LANG=en_US.UTF-8
 # c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
 ENV C_INCLUDE_PATH=/usr/include/python3.8
 ENV CPLUS_INCLUDE_PATH=/usr/include/python3.8
+# Match official Python docker image environment variables
+ENV PYTHON_VERSION="${PYTHON_VERSION}"
+ENV PYTHON_PIP_VERSION="$(python -c 'import pip; print(pip.__version__)')"
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]


### PR DESCRIPTION
Export the environmental variables `PYTHON_VERSION` and `PYTHON_PIP_VERSION` that exist in the official Python docker images:

```
$ docker run --rm python:3.8 /bin/bash -c 'printenv'
HOSTNAME=ca13b87c088f
PYTHON_VERSION=3.8.10
PWD=/
HOME=/root
LANG=C.UTF-8
GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
SHLVL=0
PYTHON_PIP_VERSION=21.1.1
PYTHON_GET_PIP_SHA256=f499d76e0149a673fb8246d88e116db589afbd291739bd84f2cd9a7bca7b6993
PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/1954f15b3f102ace496a34a013ea76b061535bd2/public/get-pip.py
PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
_=/usr/bin/printenv
```

```
* Set environmental variables PYTHON_VERSION and PYTHON_PIP_VERSION for the image
   - Match those found in the official Python Docker images
* Add a printenv step to the Docker workflow for spot checks
```