### PR TITLE
feat: Symlink pip to pip3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
     ln --symbolic --force "$(command -v python3)" "$(command -v python)" && \
+    ln --symbolic --force "$(command -v python3)" "$(command -v python)" && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
     ln --symbolic --force "$(command -v python3)" "$(command -v python)" && \
-    ln --symbolic --force "$(command -v python3)" "$(command -v python)" && \
+    ln --symbolic "$(command -v pip3)" /usr/bin/pip && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \


### PR DESCRIPTION
As a convenience feature, create a symbolic link `/usr/bin/pip` pointing to `/usr/bin/pip3` allowing one to use `pip install` instead of `pip3 install` or `python -m pip install`.

```
* Create symbolic link /usr/bin/pip pointing to /usr/bin/pip3 as a convenience feature
```