### PR TITLE
refactor: Change CPython prefix to /usr/local/

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,7 +109,7 @@ jobs:
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
           'yum --version && yum update -y'
 
-      - name: Check gcc finds /usr/include/python3.8/Python.h
+      - name: Check gcc finds /usr/local/include/python3.8/Python.h
         run: >-
           docker run --rm
           -v $PWD:$PWD

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     tar -xzf "Python-${PYTHON_VERSION}.tgz" && \
     cd "Python-${PYTHON_VERSION}" && \
     ./configure --help && \
-    ./configure --prefix=/usr \
-        --exec_prefix=/usr \
+    ./configure --prefix=/usr/local \
+        --exec_prefix=/usr/local \
         --with-ensurepip \
         --enable-optimizations \
         --with-lto \
@@ -44,7 +44,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
     ln --symbolic --force "$(command -v python3)" "$(command -v python)" && \
-    ln --symbolic "$(command -v pip3)" /usr/bin/pip && \
+    ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \
@@ -59,10 +59,10 @@ WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-# Make /usr/include/python3.8/Python.h findable by gcc
+# Make /usr/local/include/python3.8/Python.h findable by gcc
 # c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
-ENV C_INCLUDE_PATH=/usr/include/python3.8
-ENV CPLUS_INCLUDE_PATH=/usr/include/python3.8
+ENV C_INCLUDE_PATH=/usr/local/include/python3.8
+ENV CPLUS_INCLUDE_PATH=/usr/local/include/python3.8
 # Match official Python docker image environment variables
 ENV PYTHON_VERSION="${PYTHON_VERSION}"
 # pip version needs to be determined empirically for each CPython

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,10 @@ WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-# # Make /usr/local/include/python3.8/Python.h findable by gcc
-# # c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
-# ENV C_INCLUDE_PATH=/usr/local/include/python3.8
-# ENV CPLUS_INCLUDE_PATH=/usr/local/include/python3.8
+# Make /usr/local/include/python3.8/Python.h findable by gcc
+# c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
+ENV C_INCLUDE_PATH=/usr/local/include/python3.8
+ENV CPLUS_INCLUDE_PATH=/usr/local/include/python3.8
 # Match official Python docker image environment variables
 ENV PYTHON_VERSION="${PYTHON_VERSION}"
 # pip version needs to be determined empirically for each CPython

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,10 @@ WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-# Make /usr/local/include/python3.8/Python.h findable by gcc
-# c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
-ENV C_INCLUDE_PATH=/usr/local/include/python3.8
-ENV CPLUS_INCLUDE_PATH=/usr/local/include/python3.8
+# # Make /usr/local/include/python3.8/Python.h findable by gcc
+# # c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
+# ENV C_INCLUDE_PATH=/usr/local/include/python3.8
+# ENV CPLUS_INCLUDE_PATH=/usr/local/include/python3.8
 # Match official Python docker image environment variables
 ENV PYTHON_VERSION="${PYTHON_VERSION}"
 # pip version needs to be determined empirically for each CPython


### PR DESCRIPTION
To better match the setup of the official Python docker images

```console
$ docker run --rm python:3.8 /bin/bash -c 'python -m site'
sys.path = [
    '/',
    '/usr/local/lib/python38.zip',
    '/usr/local/lib/python3.8',
    '/usr/local/lib/python3.8/lib-dynload',
    '/usr/local/lib/python3.8/site-packages',
]
USER_BASE: '/root/.local' (doesn't exist)
USER_SITE: '/root/.local/lib/python3.8/site-packages' (doesn't exist)
ENABLE_USER_SITE: True
```

change the CPython install prefix from `/usr/` to `/usr/local`

```
* Update CPython prefix and exec_prefix to /usr/local
   - Matches prefixes chosen for the official python Docker images
```