### PR TITLE
fix: Correct symlink path to use /usr/local/ prefix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf "\nalias python='python3'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
-    ln --symbolic --force "$(command -v python3)" /usr/local/bin/python && \
+    ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
     ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
     cd / && \
     rm -rf /build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf "\nalias python='python3'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
-    ln --symbolic --force "$(command -v python3)" "$(command -v python)" && \
+    ln --symbolic --force "$(command -v python3)" /usr/local/bin/python && \
     ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
     cd / && \
     rm -rf /build && \


### PR DESCRIPTION
Correct symlink of `python3` to `python` to use `/usr/local/` prefix. This leaves `/usr/bin/python` as a symlink to `python2`, but `which python` still properly points to `/usr/local/bin/python`.

```
# yum install -y which
# which python
/usr/local/bin/python
# ls -l $(which python)
lrwxrwxrwx 1 root root 22 May 25 07:11 /usr/local/bin/python -> /usr/local/bin/python3
```

```
* Correct symlink of python3 to python to use /usr/local/ prefix
   - Updates /usr/bin/python to /usr/local/bin/python
* Amends PR #10
```