### PR TITLE
fix: Add readline module support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,12 +103,6 @@ jobs:
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
           'python --version --version && echo "" && python -m pip list'
 
-      - name: Check readline module built
-        run: >-
-          docker run --rm
-          neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
-          'python -c "import readline; print(readline)"'
-
       - name: Check yum still works after shebang manipulation
         run: >-
           docker run --rm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,12 @@ jobs:
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
           'python --version --version && echo "" && python -m pip list'
 
+      - name: Check readline module built
+        run: >-
+          docker run --rm
+          neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
+          'python -c "import readline"; print(readline)'
+
       - name: Check yum still works after shebang manipulation
         run: >-
           docker run --rm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,7 +107,7 @@ jobs:
         run: >-
           docker run --rm
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
-          'python -c "import readline"; print(readline)'
+          'python -c "import readline; print(readline)"'
 
       - name: Check yum still works after shebang manipulation
         run: >-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,12 @@ RUN yum update -y && \
     yum install -y \
         gcc \
         openssl-devel \
+        bzip2 \
         bzip2-devel \
         libffi-devel \
         lzma-devel \
+        zlib-devel \
+        xz-devel \
         readline-devel \
         curl \
         tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN yum update -y && \
         bzip2-devel \
         libffi-devel \
         lzma-devel \
+        readline-devel \
         curl \
         tar \
         make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN yum update -y && \
         zlib-devel \
         xz-devel \
         readline-devel \
+        sqlite \
+        sqlite-devel \
         curl \
         tar \
         make && \


### PR DESCRIPTION
Add missing dependencies to allow for CPython to build [the `readline` module](https://docs.python.org/3.8/library/readline.html).

```
* Add additional dependencies to allow for the CPython readline module to be built
   - c.f. https://docs.python.org/3.8/library/readline.html
* Add additional compression and sqlite dependencies
```