### PR TITLE
feat: Build CPython with shared python library

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,6 +117,12 @@ jobs:
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
           'gcc tests/test-gcc-include.c -o test-gcc-include && ./test-gcc-include'
 
+      - name: Check for shared python library (.so)
+        run: >-
+          docker run --rm
+          neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
+          'find /usr/ -iname "*libpython3.*"'
+
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'Neubauer-Group/centos-python3'

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,8 @@ WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
+# As --enable-shared is used put .so files in LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:"${LD_LIBRARY_PATH}"
 # Make /usr/local/include/python3.8/Python.h findable by gcc
 # c.f. http://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Environment-Variables.html#Environment-Variables
 ENV C_INCLUDE_PATH=/usr/local/include/python3.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     ./configure --prefix=/usr/local \
         --exec_prefix=/usr/local \
         --with-ensurepip \
+        --enable-shared \
         --enable-optimizations \
         --with-lto \
         --enable-ipv6 && \


### PR DESCRIPTION
Resolves #13 

Build CPython with `--enable-shared` flag to get a shared object library file

```
   --enable-shared         disable/enable building shared python library
```

```
* Add --enable-shared flag when configuring CPython build to get libpython3.X shared objects (.so)
   - From ./configure --help : --enable-shared         disable/enable building shared python library
* Set ENV variable LD_LIBRARY_PATH=/usr/local/lib to put .so files in LD_LIBRARY_PATH
   - Required for python runtime to load properly
* Add shared library spot check step to CI
* Needed for centos7 ROOT build
   - Caught as a side check for https://root-forum.cern.ch/t/root-v6-24-00-build-failure-in-centos-7-docker-image-on-auto-return-without-trailing-return-type/45238
```