### PR TITLE
feat: Add default virtual environment on PATH

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,7 +101,11 @@ jobs:
         run: >-
           docker run --rm
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}
-          'python --version --version && echo "" && python -m pip list'
+          'command -v python && \
+           echo "" && \
+           python --version --version && \
+           echo "" && \
+           python -m pip list'
 
       - name: Check yum still works after shebang manipulation
         run: >-

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
         --enable-ipv6 && \
     make -j"$(($(nproc) - 1))" && \
     make install && \
-    printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> ~/.bashrc && \
-    printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
+    printf "\n# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
     LD_LIBRARY_PATH=/usr/local/lib python3 -m venv /usr/local/venv && \
     cd / && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN yum update -y && \
 
 ARG PYTHON_VERSION=3.8.10
 WORKDIR /build
+# Set PATH to pickup virtualenv by default
+ENV PATH=/usr/local/venv/bin:"${PATH}"
 # Ensure that python means python3 even in non-interactive sessions through
 # aliases and symbolic links
 # N.B.:
@@ -47,11 +49,10 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
         --enable-ipv6 && \
     make -j"$(($(nproc) - 1))" && \
     make install && \
-    printf "\nalias python='python3'\n" >> ~/.bashrc && \
+    printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> ~/.bashrc && \
     printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
-    ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
-    ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
+    python3 -m venv /usr/local/venv && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> ~/.bashrc && \
     printf "# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
-    python3 -m venv /usr/local/venv && \
+    LD_LIBRARY_PATH=/usr/local/lib python3 -m venv /usr/local/venv && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \


### PR DESCRIPTION
This has the added benefit of symlinking the installed `python3` to the `virtualenv` PATH, so something like

```
ln -s $(command -v python3) /usr/local/venv/bin/python
```
, which then very nicely means that `python` gives you `python3` regardless of if the session is interactive or not.

This approach was recommended by Anthony Sottile in his YouTube video "[how to get pip for deadsnakes / docker pythons (intermediate) anthony explains 293](https://youtu.be/2Hg5-Hrsa6w)". Thanks Anthony!

```
* Add a venv virtual environment to PATH
   - Adding venv also symlinks the python doing the installing to virtualenv's python. This is an improvement over the approach in PR #2
   - Thanks to Anthony Sottile for recommending this approach
   - c.f. https://youtu.be/2Hg5-Hrsa6w
* Add python path spot checks to CI
```