### PR TITLE
fix: Symlink python3 to python everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
     ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
     ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
+    ln --symbolic --force "$(command -v python3)" /bin/python && \
+    ln --symbolic --force "$(command -v python3)" /usr/bin/python && \
     LD_LIBRARY_PATH=/usr/local/lib python3 -m venv /usr/local/venv && \
     cd / && \
     rm -rf /build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     make install && \
     printf "\n# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
+    ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
+    ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
     LD_LIBRARY_PATH=/usr/local/lib python3 -m venv /usr/local/venv && \
     cd / && \
     rm -rf /build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,12 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     make install && \
     printf "\n# For Python 2.7 use 'python2'\n" >> ~/.bashrc && \
     printf "# For Python 2.7 in shebangs use '#!/usr/libexec/platform-python'\n" >> ~/.bashrc && \
+    LD_LIBRARY_PATH=/usr/local/lib python3 -m venv /usr/local/venv && \
+    . /usr/local/venv/bin/activate && \
     ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
     ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
     ln --symbolic --force "$(command -v python3)" /bin/python && \
     ln --symbolic --force "$(command -v python3)" /usr/bin/python && \
-    LD_LIBRARY_PATH=/usr/local/lib python3 -m venv /usr/local/venv && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \


### PR DESCRIPTION
Create a symlink (after activating the default virtual environment)

```
ln --symbolic "$(command -v python3)" /some-location/bin/python
```

for all existing locations of `/bin/python` &mdash; that is, those found by
```
find / -iname "*python" | grep bin
```

This is needed as Shifter will prepend many `/bin` directories to the PATH at runtime, so the resolved path of `python` can get overwritten here if all instances of it aren't symlinked back to `/usr/local/bin/python/`.

```
* Symlink the default virtual environment's python3 to all instances of the python to avoid python2 getting picked up instead by PATH changes
   - Needed for working smoothly with Shifter on Blue Waters
```