### PR TITLE
revert: Remove force symlinks of /usr/bin/python and /bin/python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     . /usr/local/venv/bin/activate && \
     ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
     ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
-    ln --symbolic --force "$(command -v python3)" /bin/python && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
     ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
     ln --symbolic --force "$(command -v python3)" /bin/python && \
-    ln --symbolic --force "$(command -v python3)" /usr/bin/python && \
     cd / && \
     rm -rf /build && \
     grep --recursive '#!/usr/bin/python' /usr/bin/ \


### PR DESCRIPTION
Revert part of PR #16 

```
* Reverts the force symlinks of python3 from PR #16
   - /usr/bin/python and /bin/python are used for package management and platform processes, and so should be left untouched
   - In general forcing symlinks is probably a bad idea, especially when it is for software not under user control
* CentOS 7 systems should have users run python3 at runtime to be safe
```