### PR TITLE
fix: Remove shebang manipulation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,7 +107,7 @@ jobs:
            echo "" && \
            python -m pip list'
 
-      - name: Check yum still works after shebang manipulation
+      - name: Check yum works
         run: >-
           docker run --rm
           neubauergroup/centos-python3:sha-${GITHUB_SHA::8}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN yum update -y && \
     yum install -y devtoolset-8 && \
     yum clean all
 
-ARG PYTHON_VERSION=3.8.11
+ARG PYTHON_VERSION=3.8.10
 WORKDIR /build
 # Set PATH to pickup virtualenv by default
 ENV PATH=/usr/local/venv/bin:"${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,22 +22,12 @@ RUN yum update -y && \
     yum install -y devtoolset-8 && \
     yum clean all
 
-ARG PYTHON_VERSION=3.8.10
+ARG PYTHON_VERSION=3.8.11
 WORKDIR /build
 # Set PATH to pickup virtualenv by default
 ENV PATH=/usr/local/venv/bin:"${PATH}"
-# Ensure that python means python3 even in non-interactive sessions through
-# aliases and symbolic links
-# N.B.:
-# shebang manipulation is a bad thing to do in general and this is ONLY being
-# done to ensure that non-interatice sessions don't cause unintended bugs.
 # As soon as NCSA Blue Waters is EOL and no longer needed, switch over to
 # centos:8 immediatley.
-# The grep bit at the end:
-# * Finds all matches under /usr/bin that contain #!/usr/bin/python
-# * Ignores all matches with python3 or python2.7
-# * Strips out just the filename
-# * Passes those filenames to sed to replace the shebang with #!/usr/libexec/platform-python
 RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz" && \
     tar -xzf "Python-${PYTHON_VERSION}.tgz" && \
     cd "Python-${PYTHON_VERSION}" && \
@@ -57,18 +47,8 @@ RUN curl -sLO "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTH
     printf "\nsource scl_source enable devtoolset-8\n" >> ${HOME}/.bash_profile && \
     LD_LIBRARY_PATH=/usr/local/lib python3 -m venv /usr/local/venv && \
     . /usr/local/venv/bin/activate && \
-    ln --symbolic "$(command -v python3)" /usr/local/bin/python && \
-    ln --symbolic "$(command -v pip3)" /usr/local/bin/pip && \
     cd / && \
-    rm -rf /build && \
-    grep --recursive '#!/usr/bin/python' /usr/bin/ \
-        | grep --invert-match 'python3\|python2.7' \
-        | sed 's/:.*$//' \
-        | xargs sed --in-place 's|#!/usr/bin/python|#!/usr/libexec/platform-python|g' && \
-    grep --recursive '#!' /usr/libexec/ \
-        | grep "python" \
-        | sed 's/:.*$//' \
-        | xargs sed --in-place 's|/usr/bin/python|/usr/libexec/platform-python|g'
+    rm -rf /build
 WORKDIR /
 
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Remove shebang manipulation and symlinking as this is better resolved through using a default Python virtual environment.

Example:

```console
$ docker run --rm neubauergroup/centos-python3:3.8.10 'which python && python --version --version && which pip && pip --version && /usr/bin/python --version --version && /usr/bin/python -m pip --version'
/usr/local/venv/bin/python
Python 3.8.10 (default, Aug  2 2021, 18:44:03) 
[GCC 8.3.1 20190311 (Red Hat 8.3.1-3)]
/usr/local/venv/bin/pip
pip 21.1.1 from /usr/local/venv/lib/python3.8/site-packages/pip (python 3.8)
Python 2.7.5
/usr/bin/python: No module named pip
```

```
* Remove shebang manipulation and symlinking
   - The default virtual environment at /usr/local/venv is picked up and shields from python 2 vs. python 3 confusion in `python` calls
```